### PR TITLE
Update Updater.php

### DIFF
--- a/src/Package/Updater.php
+++ b/src/Package/Updater.php
@@ -27,7 +27,9 @@ class Updater
 
     private function getPackagePluginFiles(): array
     {
-        if (count($this->pluginFiles) !== 0) {
+        static $hasRun = false;
+        
+        if ($hasRun || count($this->pluginFiles) !== 0) {
             return $this->pluginFiles;
         }
 
@@ -46,6 +48,8 @@ class Updater
                 $return[$key] = $file;
             }
         }
+
+        $hasRun = true;
         $this->pluginFiles = $return;
         return $return;
     }


### PR DESCRIPTION
If no tracked plugin is specified, some code is run for each plugin meta, so I avoided that and made sure it was only run once. When you have 180 plugins, most of which are disabled - in dev env, this really takes time...