### PR TITLE
Add CI workflow for typo checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  spelling:
+    name: Typos
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: crate-ci/typos@v1
-        with:
-          args: --exclude "*.min.js"
+      - uses: crate-ci/typos@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@v1
+        with:
+          args: --exclude "*.min.js"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["assets"]


### PR DESCRIPTION
First easy check for typos. If interested, we can add more, like PHPStan, WPCS and Plugin Check.
See: #82 